### PR TITLE
Bug fix to str_replace_all for graphiz attributes hack

### DIFF
--- a/R/renderer.R
+++ b/R/renderer.R
@@ -31,8 +31,8 @@ renderer_graphviz <- function(svg_fit = TRUE,
 
     # hack to add 'weight' attribute to the graph (see same approach in processmapR)
     diagram %>%
-      stringr::str_replace_all("len", "weight") %>%
-      stringr::str_replace_all("decorate", "constraint")
+      stringr::str_replace_all(", len = ", ", weight = ") %>%
+      stringr::str_replace_all(", decorate = ", ", constraint = ")
   }
 
   attr(render, "name") <- "graph"


### PR DESCRIPTION
Force the str_replace_all functies to focus on attributes in the diagram. Previously would also replace "len" and "decorate" if the words would occur in the activity labels. 